### PR TITLE
[RISCV] Allow libunwind to build for rv32e (#98855)

### DIFF
--- a/libunwind/src/UnwindRegistersRestore.S
+++ b/libunwind/src/UnwindRegistersRestore.S
@@ -1183,7 +1183,11 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
     ILOAD x\i, (RISCV_ISIZE * \i)(a0)
   .endr
   // skip a0 for now
+#if defined(__riscv_32e)
+  .irp i,11,12,13,14,15
+#else
   .irp i,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
+#endif
     ILOAD x\i, (RISCV_ISIZE * \i)(a0)
   .endr
   ILOAD    x10, (RISCV_ISIZE * 10)(a0)   // restore a0

--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -1108,7 +1108,11 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 #
 DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
   ISTORE    x1, (RISCV_ISIZE * 0)(a0) // store ra as pc
+#if defined(__riscv_32e)
+  .irp i,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+#else
   .irp i,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
+#endif
     ISTORE x\i, (RISCV_ISIZE * \i)(a0)
   .endr
 


### PR DESCRIPTION
Don't try to save x16-x31 when using rv32e ISA

Note that I haven't actually tested yet whether or not unwinding actually works on rv32e, but the code as-is doesn't even build.

(cherry picked from commit b33a675e3f5710bd56715e8058b541c21c325de0)